### PR TITLE
Added ability to set padding via props

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ var Application = React.createClass({
 ### Properties
 * `active` (Boolean) - Initial switch state (default: false),
 * `style` (Object) - Styles for outer container (margins, ...),
+* `padding` (Integer) - Padding of outer container (default: 2),
 * `inactiveButtonColor` (String) - Button color  (default: '#2196F3'),
 * `inactiveButtonPressedColor` (String) (default: '#42A5F5'),
 * `activeButtonColor` (String) (default: '#FAFAFA'),

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ class Switch extends React.Component {
       state: this.props.active,
       position: new Animated.Value(this.props.active ? w : 0),
     };
-    this.padding = 2;
     this.start = {};
   }
 
@@ -166,12 +165,12 @@ class Switch extends React.Component {
   };
 
   render() {
-    let doublePadding = this.padding * 2 - 2;
+    let doublePadding = this.props.padding * 2 - 2;
     let halfPadding = doublePadding / 2;
     return (
       <View
         {...this._panResponder.panHandlers}
-        style={{padding: this.padding, position: 'relative'}}>
+        style={{padding: this.props.padding, position: 'relative'}}>
         <View
           style={{
             backgroundColor: this.state.state ? this.props.activeBackgroundColor : this.props.inactiveBackgroundColor,
@@ -216,6 +215,7 @@ class Switch extends React.Component {
 Switch.defaultProps = {
   active: false,
   style: {},
+  padding: 2,
   inactiveButtonColor: '#2196F3',
   inactiveButtonPressedColor: '#42A5F5',
   activeButtonColor: '#FAFAFA',


### PR DESCRIPTION
Because with default padding equals 2 the switch may be clipped on Android (depends on styles)